### PR TITLE
Also skip `vendor` directory.

### DIFF
--- a/import.go
+++ b/import.go
@@ -205,9 +205,9 @@ func matchPackages(pattern string) []string {
 				return nil
 			}
 
-			// Avoid .foo, _foo, and testdata directory trees.
+			// Avoid .foo, _foo, testdata and vendor directory trees.
 			_, elem := filepath.Split(path)
-			if strings.HasPrefix(elem, ".") || strings.HasPrefix(elem, "_") || elem == "testdata" {
+			if strings.HasPrefix(elem, ".") || strings.HasPrefix(elem, "_") || elem == "testdata" || elem == "vendor" {
 				return filepath.SkipDir
 			}
 
@@ -286,10 +286,10 @@ func matchPackagesInFS(pattern string) []string {
 			path = filepath.Clean(path)
 		}
 
-		// Avoid .foo, _foo, and testdata directory trees, but do not avoid "." or "..".
+		// Avoid .foo, _foo, testdata and vendor directory trees, but do not avoid "." or "..".
 		_, elem := filepath.Split(path)
 		dot := strings.HasPrefix(elem, ".") && elem != "." && elem != ".."
-		if dot || strings.HasPrefix(elem, "_") || elem == "testdata" {
+		if dot || strings.HasPrefix(elem, "_") || elem == "testdata" || elem == "vendor" {
 			return filepath.SkipDir
 		}
 


### PR DESCRIPTION
This change makes nakedret also skip the vendor directory. In general this sort of static analysis is run on the project itself, not on its dependencies, so I didn't think it warranted being an option, but I can do that instead if you'd rather.