### PR TITLE
Fix bug with not detected nested returns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# editor specific
+.vscode
+
+# binary
+nakedret

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/alexkohler/nakedret
+
+go 1.13

--- a/nakedret.go
+++ b/nakedret.go
@@ -191,21 +191,20 @@ func (v *returnsVisitor) Visit(node ast.Node) ast.Visitor {
 	if len(namedReturns) > 0 && funcDecl.Body != nil {
 		// Scan the body for usage of the named returns
 		for _, stmt := range funcDecl.Body.List {
-
-			switch s := stmt.(type) {
-			case *ast.ReturnStmt:
-				if len(s.Results) == 0 {
-					file := v.f.File(s.Pos())
-					if file != nil && uint(functionLineLength) > v.maxLength {
-						if funcDecl.Name != nil {
-							log.Printf("%v:%v %v naked returns on %v line function \n", file.Name(), file.Position(s.Pos()).Line, funcDecl.Name.Name, functionLineLength)
+			// Find return statements and report if invalid
+			ast.Inspect(stmt, func(n ast.Node) bool {
+				if ret, ok := n.(*ast.ReturnStmt); ok {
+					if len(ret.Results) == 0 {
+						file := v.f.File(ret.Pos())
+						if file != nil && uint(functionLineLength) > v.maxLength {
+							if funcDecl.Name != nil {
+								log.Printf("%v:%v %v naked returns on %v line function \n", file.Name(), file.Position(ret.Pos()).Line, funcDecl.Name.Name, functionLineLength)
+							}
 						}
 					}
-					continue
 				}
-
-			default:
-			}
+				return true
+			})
 		}
 	}
 


### PR DESCRIPTION
Howdy!

I detected that in case of file like below:
```go
package x

import "fmt"

func Dummy() (err error) {
	fmt.Println("My Dummy function")
	fmt.Println("This condition only exists to show a nested return")
	if 1 == 1 {
		return
	}
	fmt.Println("Greetings")
	return nil
}
```

when I run:
```
nakedret -l 5 x.go 
```

I didn't get any message about naked return. But obviously there is a naked return and function is longer than `5` lines, so I should have got an info.

In this PR I fixed it and now the tool for cases like the above reports:

```
x.go:9 Dummy naked returns on 8 line function
```
It works robustly for every level of nesting for return statement.