### PR TITLE
Add simple unit tests

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,0 +1,17 @@
+name: build-test
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v1
+        with:
+          go-version: 1.13.x
+      - uses: actions/checkout@v2
+      - name: Build
+        run: go build .
+      - name: Test
+        run: go test -v .

--- a/nakedret.go
+++ b/nakedret.go
@@ -205,7 +205,7 @@ func (v *returnsVisitor) Visit(node ast.Node) ast.Visitor {
 		// We've found a possibly naked return statement
 		if v.reportNaked && len(s.Results) == 0 {
 			file := v.f.File(s.Pos())
-			log.Printf("%v:%v %v naked returns on %v line function \n", file.Name(), file.Position(s.Pos()).Line, v.funcName, v.funcLength)
+			log.Printf("%v:%v %v naked returns on %v line function\n", file.Name(), file.Position(s.Pos()).Line, v.funcName, v.funcLength)
 		}
 	}
 

--- a/nakedret_test.go
+++ b/nakedret_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"bytes"
+	"log"
+	"os"
+	"testing"
+)
+
+func runNakedret(t *testing.T, filename string, maxLength uint, expected string) {
+	t.Helper()
+	defer func() {
+		// Reset logging
+		log.SetOutput(os.Stderr)
+		log.SetFlags(log.LstdFlags)
+	}()
+	var logBuf bytes.Buffer
+	log.SetOutput(&logBuf)
+	log.SetFlags(0)
+
+	if err := checkNakedReturns([]string{filename}, &maxLength); err != nil {
+		t.Fatal(err)
+	}
+	actual := string(logBuf.Bytes())
+	if expected != actual {
+		t.Errorf("Unexpected output:\n-----\n%s\n-----\n", actual)
+	}
+}
+
+func TestReturnInBlock(t *testing.T) {
+	expected := `testdata/ret-in-block.go:9 Dummy naked returns on 8 line function
+`
+	runNakedret(t, "testdata/ret-in-block.go", 0, expected)
+}
+
+func TestIgnoreShortFunctions(t *testing.T) {
+	runNakedret(t, "testdata/ret-in-block.go", 10, "")
+}
+
+func TestNestedFunctionLiterals(t *testing.T) {
+	expected := `testdata/nested.go:16 Bad naked returns on 6 line function
+testdata/nested.go:21 <func():20> naked returns on 2 line function
+`
+	runNakedret(t, "testdata/nested.go", 0, expected)
+}

--- a/testdata/nested.go
+++ b/testdata/nested.go
@@ -1,0 +1,24 @@
+package x
+
+func Okay() (err error) {
+	defer func() {
+		// This is okay because it belongs to the function literal
+		return
+	}()
+	return err
+}
+
+func Bad() (err error) {
+	defer func() {
+		// This is okay because it belongs to the function literal
+		return
+	}()
+	return
+}
+
+func BadNested() {
+	f := func() (i int) {
+		return
+	}
+	return
+}

--- a/testdata/ret-in-block.go
+++ b/testdata/ret-in-block.go
@@ -1,0 +1,13 @@
+package x
+
+import "fmt"
+
+func Dummy() (err error) {
+	fmt.Println("My Dummy function")
+	fmt.Println("This condition only exists to show a nested return")
+	if 1 == 1 {
+		return
+	}
+	fmt.Println("Greetings")
+	return nil
+}


### PR DESCRIPTION
This branch adds a few simple high level unit tests, together with a Github Actions workflow to run them (hopefully it will actually run within the PR prior to landing).

The unit tests invoke `checkNakedReturns` with various input files, and check to see that the appropriate output is logged.