### PR TITLE
add : into result message so that Emacs recognizes it

### DIFF
--- a/nakedret.go
+++ b/nakedret.go
@@ -205,7 +205,7 @@ func (v *returnsVisitor) Visit(node ast.Node) ast.Visitor {
 		// We've found a possibly naked return statement
 		if v.reportNaked && len(s.Results) == 0 {
 			file := v.f.File(s.Pos())
-			log.Printf("%v:%v %v naked returns on %v line function\n", file.Name(), file.Position(s.Pos()).Line, v.funcName, v.funcLength)
+			log.Printf("%v:%v: %v naked returns on %v line function\n", file.Name(), file.Position(s.Pos()).Line, v.funcName, v.funcLength)
 		}
 	}
 

--- a/nakedret_test.go
+++ b/nakedret_test.go
@@ -28,7 +28,7 @@ func runNakedret(t *testing.T, filename string, maxLength uint, expected string)
 }
 
 func TestReturnInBlock(t *testing.T) {
-	expected := `testdata/ret-in-block.go:9 Dummy naked returns on 8 line function
+	expected := `testdata/ret-in-block.go:9: Dummy naked returns on 8 line function
 `
 	runNakedret(t, "testdata/ret-in-block.go", 0, expected)
 }
@@ -38,8 +38,8 @@ func TestIgnoreShortFunctions(t *testing.T) {
 }
 
 func TestNestedFunctionLiterals(t *testing.T) {
-	expected := `testdata/nested.go:16 Bad naked returns on 6 line function
-testdata/nested.go:21 <func():20> naked returns on 2 line function
+	expected := `testdata/nested.go:16: Bad naked returns on 6 line function
+testdata/nested.go:21: <func():20> naked returns on 2 line function
 `
 	runNakedret(t, "testdata/nested.go", 0, expected)
 }


### PR DESCRIPTION
With this change, Emacs users can use `M-g n` and `M-g p` to go to the next/previous error in the compilation window, which allows Emacs users to use nakedret with compilation mode (very convenient) :)