### PR TITLE
set exit status if issues found and flag set, and on parse error

### DIFF
--- a/nakedret_test.go
+++ b/nakedret_test.go
@@ -18,7 +18,7 @@ func runNakedret(t *testing.T, filename string, maxLength uint, expected string)
 	log.SetOutput(&logBuf)
 	log.SetFlags(0)
 
-	if err := checkNakedReturns([]string{filename}, &maxLength); err != nil {
+	if err := checkNakedReturns([]string{filename}, &maxLength, false); err != nil {
 		t.Fatal(err)
 	}
 	actual := string(logBuf.Bytes())


### PR DESCRIPTION
This change adds a `set_exit_status` flag which makes `nakedret` set
its exit status of 1 if it finds any issues. It also makes it set an
exit status of 2 when it finds errors.

Fixes #7.