### PR TITLE
Update go.mod and internal imports for v2

### DIFF
--- a/cmd/nakedret/main.go
+++ b/cmd/nakedret/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"golang.org/x/tools/go/analysis/singlechecker"
 
-	"github.com/alexkohler/nakedret"
+	"github.com/alexkohler/nakedret/v2"
 )
 
 const (

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/alexkohler/nakedret
+module github.com/alexkohler/nakedret/v2
 
 go 1.18
 


### PR DESCRIPTION
I think these updates are required for v2.

A bit surprising, as this article argues:
[Go Modules have a v2+ Problem](https://donatstudios.com/Go-v2-Modules)
> "Go modules place a strange naming requirement on modules version 2 or greater. Module names on modules v2+ must end in the major version ala …/v2, and communication of this rule has been weak. It's non-obvious, and the community at large does not understand it.
>
> I have seen many very large projects including Google owned projects get it wrong.
>
> I brought the issue up at my local Go meetup, and no one had ever heard about the rule. They were very skeptical the rule existed at all."

And here's the Go blog reference on this:
[Go Modules: v2 and Beyond](https://go.dev/blog/v2-go-modules)
> "a new major version of a module must have a different module path than the previous version. Starting with v2, the major version must appear at the end of the module path (declared in the module statement in the go.mod file)."

