### PR TITLE
fix: move init to the main package

### DIFF
--- a/cmd/nakedret/main.go
+++ b/cmd/nakedret/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"go/build"
+
 	"golang.org/x/tools/go/analysis/singlechecker"
 
 	"github.com/alexkohler/nakedret/v2"
@@ -9,6 +11,11 @@ import (
 const (
 	DefaultLines = 5
 )
+
+func init() {
+	// TODO allow build tags
+	build.Default.UseAllFiles = true
+}
 
 func main() {
 	analyzer := nakedret.NakedReturnAnalyzer(DefaultLines)

--- a/nakedret.go
+++ b/nakedret.go
@@ -20,14 +20,7 @@ import (
 	"golang.org/x/tools/go/ast/inspector"
 )
 
-const (
-	pwd = "./"
-)
-
-func init() {
-	//TODO allow build tags
-	build.Default.UseAllFiles = true
-}
+const pwd = "./"
 
 func NakedReturnAnalyzer(defaultLines uint) *analysis.Analyzer {
 	nakedRet := &NakedReturnRunner{}
@@ -149,7 +142,7 @@ func parseInput(args []string, fset *token.FileSet) ([]*ast.File, error) {
 				}
 			} else {
 
-				//TODO clean this up a bit
+				// TODO clean this up a bit
 				imPaths := importPaths([]string{arg})
 				for _, importPath := range imPaths {
 					pkg, err := build.Import(importPath, ".", 0)


### PR DESCRIPTION
The `init` function modifies the global variable `build.Default` but this impacts golangci-lint and Kubernetes.

https://gophers.slack.com/archives/CS0TBRKPC/p1686144370506279