### PR TITLE
Update install instruction with v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ nakedret is a Go static analysis tool to find naked returns in functions greater
 Install Nakedret via go install:
 
 ```cmd
-go install github.com/alexkohler/nakedret/cmd/nakedret@latest
+go install github.com/alexkohler/nakedret/v2/cmd/nakedret@latest
 ```
 
 If you have not already added your `GOPATH/bin` directory to your `PATH` environment variable then you will need to do so.


### PR DESCRIPTION
Ever since the module import path was amended to include "v2" in https://github.com/alexkohler/nakedret/pull/27, the install instructions will only install the v1 module. This PR updates the install instructions to match the current import path.

Fixes #36