### PR TITLE
fix: CLI flags parsing

### DIFF
--- a/cmd/nakedret/main.go
+++ b/cmd/nakedret/main.go
@@ -19,6 +19,12 @@ func init() {
 }
 
 func main() {
-	analyzer := nakedret.NakedReturnAnalyzer(DefaultLines, DefaultSkipTestFiles)
+	nakedRet := &nakedret.NakedReturnRunner{}
+
+	analyzer := nakedret.NakedReturnAnalyzer(nakedRet)
+
+	analyzer.Flags.UintVar(&nakedRet.MaxLength, "l", DefaultLines, "maximum number of lines for a naked return function")
+	analyzer.Flags.BoolVar(&nakedRet.SkipTestFiles, "skip-test-files", DefaultSkipTestFiles, "set to true to skip test files")
+
 	singlechecker.Main(analyzer)
 }

--- a/cmd/nakedret/main.go
+++ b/cmd/nakedret/main.go
@@ -1,7 +1,13 @@
 package main
 
 import (
+	"flag"
+	"fmt"
 	"go/build"
+	"os"
+	"path/filepath"
+	"runtime"
+	"runtime/debug"
 
 	"golang.org/x/tools/go/analysis/singlechecker"
 
@@ -23,8 +29,27 @@ func main() {
 
 	analyzer := nakedret.NakedReturnAnalyzer(nakedRet)
 
+	analyzer.Flags.Init("nakedret", flag.ExitOnError)
+
 	analyzer.Flags.UintVar(&nakedRet.MaxLength, "l", DefaultLines, "maximum number of lines for a naked return function")
 	analyzer.Flags.BoolVar(&nakedRet.SkipTestFiles, "skip-test-files", DefaultSkipTestFiles, "set to true to skip test files")
+	analyzer.Flags.Var(versionFlag{}, "V", "print version and exit")
 
 	singlechecker.Main(analyzer)
+}
+
+type versionFlag struct{}
+
+func (versionFlag) IsBoolFlag() bool { return true }
+func (versionFlag) Get() any         { return nil }
+func (versionFlag) String() string   { return "" }
+func (versionFlag) Set(s string) error {
+	info, ok := debug.ReadBuildInfo()
+	if ok {
+		fmt.Fprintf(os.Stderr, "%s version %s built with %s (%s/%s)\n",
+			filepath.Base(os.Args[0]), info.Main.Version, info.GoVersion, runtime.GOOS, runtime.GOARCH)
+	}
+
+	os.Exit(0)
+	return nil
 }

--- a/nakedret.go
+++ b/nakedret.go
@@ -21,18 +21,13 @@ import (
 
 const pwd = "./"
 
-func NakedReturnAnalyzer(defaultLines uint, skipTestFiles bool) *analysis.Analyzer {
-	nakedRet := &NakedReturnRunner{}
-
+func NakedReturnAnalyzer(nakedRet *NakedReturnRunner) *analysis.Analyzer {
 	a := &analysis.Analyzer{
 		Name:     "nakedret",
 		Doc:      "Checks that functions with naked returns are not longer than a maximum size (can be zero).",
 		Run:      nakedRet.run,
 		Requires: []*analysis.Analyzer{inspect.Analyzer},
 	}
-
-	a.Flags.UintVar(&nakedRet.MaxLength, "l", defaultLines, "maximum number of lines for a naked return function")
-	a.Flags.BoolVar(&nakedRet.SkipTestFiles, "skip-test-files", skipTestFiles, "set to true to skip test files")
 
 	return a
 }
@@ -91,7 +86,7 @@ func checkNakedReturns(args []string, maxLength *uint, skipTestFiles bool, setEx
 		return errors.New("max length nil")
 	}
 
-	analyzer := NakedReturnAnalyzer(*maxLength, skipTestFiles)
+	analyzer := NakedReturnAnalyzer(&NakedReturnRunner{MaxLength: *maxLength, SkipTestFiles: skipTestFiles})
 	pass := &analysis.Pass{
 		Analyzer: analyzer,
 		Fset:     fset,

--- a/nakedret.go
+++ b/nakedret.go
@@ -3,7 +3,6 @@ package nakedret
 import (
 	"bytes"
 	"errors"
-	"flag"
 	"fmt"
 	"go/ast"
 	"go/build"
@@ -24,17 +23,18 @@ const pwd = "./"
 
 func NakedReturnAnalyzer(defaultLines uint, skipTestFiles bool) *analysis.Analyzer {
 	nakedRet := &NakedReturnRunner{}
-	flags := flag.NewFlagSet("nakedret", flag.ExitOnError)
-	flags.UintVar(&nakedRet.MaxLength, "l", defaultLines, "maximum number of lines for a naked return function")
-	flags.BoolVar(&nakedRet.SkipTestFiles, "skip-test-files", skipTestFiles, "set to true to skip test files")
-	var analyzer = &analysis.Analyzer{
+
+	a := &analysis.Analyzer{
 		Name:     "nakedret",
 		Doc:      "Checks that functions with naked returns are not longer than a maximum size (can be zero).",
 		Run:      nakedRet.run,
-		Flags:    *flags,
 		Requires: []*analysis.Analyzer{inspect.Analyzer},
 	}
-	return analyzer
+
+	a.Flags.UintVar(&nakedRet.MaxLength, "l", defaultLines, "maximum number of lines for a naked return function")
+	a.Flags.BoolVar(&nakedRet.SkipTestFiles, "skip-test-files", skipTestFiles, "set to true to skip test files")
+
+	return a
 }
 
 type NakedReturnRunner struct {

--- a/nakedret_test.go
+++ b/nakedret_test.go
@@ -109,7 +109,7 @@ func TestAll(t *testing.T) {
 	}
 
 	testdata := filepath.Join(wd, "testdata")
-	analysistest.Run(t, testdata, NakedReturnAnalyzer(0, true), "x")
+	analysistest.Run(t, testdata, NakedReturnAnalyzer(&NakedReturnRunner{SkipTestFiles: true}), "x")
 }
 
 func TestAllFixes(t *testing.T) {
@@ -119,5 +119,5 @@ func TestAllFixes(t *testing.T) {
 	}
 
 	testdata := filepath.Join(wd, "testdata")
-	analysistest.RunWithSuggestedFixes(t, testdata, NakedReturnAnalyzer(0, true), "x")
+	analysistest.RunWithSuggestedFixes(t, testdata, NakedReturnAnalyzer(&NakedReturnRunner{0, true}), "x")
 }


### PR DESCRIPTION
```console
$ go run ./cmd/nakedret -V
nakedret version (devel) built with go1.24.1 (linux/amd64)
```

Fixes #40
Closes #4
