### PR TITLE
chore: add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: monthly

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,14 +1,17 @@
 name: build-test
 on:
   push:
+    branches:
+      - master
   pull_request:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         go-version: [ oldstable, stable ]
+        os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
The dependabot will check once a month if `x/tools` needs to be updated.

If an update is available, it will open a PR.